### PR TITLE
Speed up Insert

### DIFF
--- a/radix.go
+++ b/radix.go
@@ -40,8 +40,14 @@ func (n *node) isLeaf() bool {
 }
 
 func (n *node) addEdge(e edge) {
-	n.edges = append(n.edges, e)
-	n.edges.Sort()
+	num := len(n.edges)
+	idx := sort.Search(num, func(i int) bool {
+		return n.edges[i].label >= e.label
+	})
+
+	n.edges = append(n.edges, edge{})
+	copy(n.edges[idx+1:], n.edges[idx:])
+	n.edges[idx] = e
 }
 
 func (n *node) updateEdge(label byte, node *node) {


### PR DESCRIPTION
Rewrite `addEdge` to use binary search to insert the element in the already sorted slice.

Benchmark for `Insert`:

```
name       old time/op    new time/op    delta
Insert-10     266ns ± 1%     233ns ± 2%  -12.33%  (p=0.029 n=4+4)

name       old alloc/op   new alloc/op   delta
Insert-10      161B ± 0%      137B ± 0%  -14.91%  (p=0.029 n=4+4)

name       old allocs/op  new allocs/op  delta
Insert-10      4.00 ± 0%      3.00 ± 0%  -25.00%  (p=0.029 n=4+4)
```
