### PR TITLE
Make it generic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+*.test

--- a/radix.go
+++ b/radix.go
@@ -8,23 +8,23 @@ import (
 // WalkFn is used when walking the tree. Takes a
 // key and value, returning if iteration should
 // be terminated.
-type WalkFn func(s string, v any) bool
+type WalkFn[T any] func(s string, v T) bool
 
 // leafNode is used to represent a value
-type leafNode struct {
+type leafNode[T any] struct {
 	key string
-	val any
+	val T
 }
 
 // edge is used to represent an edge node
-type edge struct {
+type edge[T any] struct {
 	label byte
-	node  *node
+	node  *node[T]
 }
 
-type node struct {
+type node[T any] struct {
 	// leaf is used to store possible leaf
-	leaf *leafNode
+	leaf *leafNode[T]
 
 	// prefix is the common prefix we ignore
 	prefix string
@@ -32,25 +32,25 @@ type node struct {
 	// Edges should be stored in-order for iteration.
 	// We avoid a fully materialized slice to save memory,
 	// since in most cases we expect to be sparse
-	edges edges
+	edges edges[T]
 }
 
-func (n *node) isLeaf() bool {
+func (n *node[T]) isLeaf() bool {
 	return n.leaf != nil
 }
 
-func (n *node) addEdge(e edge) {
+func (n *node[T]) addEdge(e edge[T]) {
 	num := len(n.edges)
 	idx := sort.Search(num, func(i int) bool {
 		return n.edges[i].label >= e.label
 	})
 
-	n.edges = append(n.edges, edge{})
+	n.edges = append(n.edges, edge[T]{})
 	copy(n.edges[idx+1:], n.edges[idx:])
 	n.edges[idx] = e
 }
 
-func (n *node) updateEdge(label byte, node *node) {
+func (n *node[T]) updateEdge(label byte, node *node[T]) {
 	num := len(n.edges)
 	idx := sort.Search(num, func(i int) bool {
 		return n.edges[i].label >= label
@@ -62,7 +62,7 @@ func (n *node) updateEdge(label byte, node *node) {
 	panic("replacing missing edge")
 }
 
-func (n *node) getEdge(label byte) *node {
+func (n *node[T]) getEdge(label byte) *node[T] {
 	num := len(n.edges)
 	idx := sort.Search(num, func(i int) bool {
 		return n.edges[i].label >= label
@@ -73,33 +73,33 @@ func (n *node) getEdge(label byte) *node {
 	return nil
 }
 
-func (n *node) delEdge(label byte) {
+func (n *node[T]) delEdge(label byte) {
 	num := len(n.edges)
 	idx := sort.Search(num, func(i int) bool {
 		return n.edges[i].label >= label
 	})
 	if idx < num && n.edges[idx].label == label {
 		copy(n.edges[idx:], n.edges[idx+1:])
-		n.edges[len(n.edges)-1] = edge{}
+		n.edges[len(n.edges)-1] = edge[T]{}
 		n.edges = n.edges[:len(n.edges)-1]
 	}
 }
 
-type edges []edge
+type edges[T any] []edge[T]
 
-func (e edges) Len() int {
+func (e edges[T]) Len() int {
 	return len(e)
 }
 
-func (e edges) Less(i, j int) bool {
+func (e edges[T]) Less(i, j int) bool {
 	return e[i].label < e[j].label
 }
 
-func (e edges) Swap(i, j int) {
+func (e edges[T]) Swap(i, j int) {
 	e[i], e[j] = e[j], e[i]
 }
 
-func (e edges) Sort() {
+func (e edges[T]) Sort() {
 	sort.Sort(e)
 }
 
@@ -107,20 +107,20 @@ func (e edges) Sort() {
 // Dictionary abstract data type. The main advantage over
 // a standard hash map is prefix-based lookups and
 // ordered iteration,
-type Tree struct {
-	root *node
+type Tree[T any] struct {
+	root *node[T]
 	size int
 }
 
 // New returns an empty Tree
-func New() *Tree {
-	return NewFromMap(nil)
+func New[T any]() *Tree[T] {
+	return NewFromMap[T](nil)
 }
 
 // NewFromMap returns a new tree containing the keys
 // from an existing map
-func NewFromMap(m map[string]any) *Tree {
-	t := &Tree{root: &node{}}
+func NewFromMap[T any](m map[string]T) *Tree[T] {
+	t := &Tree[T]{root: &node[T]{}}
 	for k, v := range m {
 		t.Insert(k, v)
 	}
@@ -128,7 +128,7 @@ func NewFromMap(m map[string]any) *Tree {
 }
 
 // Len is used to return the number of elements in the tree
-func (t *Tree) Len() int {
+func (t *Tree[T]) Len() int {
 	return t.size
 }
 
@@ -150,8 +150,8 @@ func longestPrefix(k1, k2 string) int {
 
 // Insert is used to add a newentry or update
 // an existing entry. Returns true if an existing record is updated.
-func (t *Tree) Insert(s string, v any) (any, bool) {
-	var parent *node
+func (t *Tree[T]) Insert(s string, v T) (T, bool) {
+	var parent *node[T]
 	n := t.root
 	search := s
 	for {
@@ -163,12 +163,13 @@ func (t *Tree) Insert(s string, v any) (any, bool) {
 				return old, true
 			}
 
-			n.leaf = &leafNode{
+			n.leaf = &leafNode[T]{
 				key: s,
 				val: v,
 			}
 			t.size++
-			return nil, false
+			var zero T
+			return zero, false
 		}
 
 		// Look for the edge
@@ -177,10 +178,10 @@ func (t *Tree) Insert(s string, v any) (any, bool) {
 
 		// No edge, create one
 		if n == nil {
-			e := edge{
+			e := edge[T]{
 				label: search[0],
-				node: &node{
-					leaf: &leafNode{
+				node: &node[T]{
+					leaf: &leafNode[T]{
 						key: s,
 						val: v,
 					},
@@ -189,7 +190,8 @@ func (t *Tree) Insert(s string, v any) (any, bool) {
 			}
 			parent.addEdge(e)
 			t.size++
-			return nil, false
+			var zero T
+			return zero, false
 		}
 
 		// Determine longest prefix of the search key on match
@@ -201,20 +203,20 @@ func (t *Tree) Insert(s string, v any) (any, bool) {
 
 		// Split the node
 		t.size++
-		child := &node{
+		child := &node[T]{
 			prefix: search[:commonPrefix],
 		}
 		parent.updateEdge(search[0], child)
 
 		// Restore the existing node
-		child.addEdge(edge{
+		child.addEdge(edge[T]{
 			label: n.prefix[commonPrefix],
 			node:  n,
 		})
 		n.prefix = n.prefix[commonPrefix:]
 
 		// Create a new leaf node
-		leaf := &leafNode{
+		leaf := &leafNode[T]{
 			key: s,
 			val: v,
 		}
@@ -223,28 +225,31 @@ func (t *Tree) Insert(s string, v any) (any, bool) {
 		search = search[commonPrefix:]
 		if len(search) == 0 {
 			child.leaf = leaf
-			return nil, false
+			var zero T
+			return zero, false
 		}
 
 		// Create a new edge for the node
-		child.addEdge(edge{
+		child.addEdge(edge[T]{
 			label: search[0],
-			node: &node{
+			node: &node[T]{
 				leaf:   leaf,
 				prefix: search,
 			},
 		})
-		return nil, false
+		var zero T
+		return zero, false
 	}
 }
 
 // Delete is used to delete a key, returning the previous
 // value and if it was deleted
-func (t *Tree) Delete(s string) (any, bool) {
-	var parent *node
+func (t *Tree[T]) Delete(s string) (T, bool) {
+	var parent *node[T]
 	var label byte
 	n := t.root
 	search := s
+	var zero T
 	for {
 		// Check for key exhaution
 		if len(search) == 0 {
@@ -269,7 +274,7 @@ func (t *Tree) Delete(s string) (any, bool) {
 			break
 		}
 	}
-	return nil, false
+	return zero, false
 
 DELETE:
 	// Delete the leaf
@@ -298,18 +303,18 @@ DELETE:
 // DeletePrefix is used to delete the subtree under a prefix
 // Returns how many nodes were deleted
 // Use this to delete large subtrees efficiently
-func (t *Tree) DeletePrefix(s string) int {
+func (t *Tree[T]) DeletePrefix(s string) int {
 	return t.deletePrefix(nil, t.root, s)
 }
 
 // delete does a recursive deletion
-func (t *Tree) deletePrefix(parent, n *node, prefix string) int {
+func (t *Tree[T]) deletePrefix(parent, n *node[T], prefix string) int {
 	// Check for key exhaustion
 	if len(prefix) == 0 {
 		// Remove the leaf node
 		subTreeSize := 0
 		//recursively walk from all edges of the node to be deleted
-		recursiveWalk(n, func(s string, v any) bool {
+		recursiveWalk(n, func(s string, v T) bool {
 			subTreeSize++
 			return false
 		})
@@ -342,7 +347,7 @@ func (t *Tree) deletePrefix(parent, n *node, prefix string) int {
 	return t.deletePrefix(n, child, prefix)
 }
 
-func (n *node) mergeChild() {
+func (n *node[T]) mergeChild() {
 	e := n.edges[0]
 	child := e.node
 	n.prefix = n.prefix + child.prefix
@@ -352,7 +357,7 @@ func (n *node) mergeChild() {
 
 // Get is used to lookup a specific key, returning
 // the value and if it was found
-func (t *Tree) Get(s string) (any, bool) {
+func (t *Tree[T]) Get(s string) (T, bool) {
 	n := t.root
 	search := s
 	for {
@@ -377,13 +382,14 @@ func (t *Tree) Get(s string) (any, bool) {
 			break
 		}
 	}
-	return nil, false
+	var zero T
+	return zero, false
 }
 
 // LongestPrefix is like Get, but instead of an
 // exact match, it will return the longest prefix match.
-func (t *Tree) LongestPrefix(s string) (string, any, bool) {
-	var last *leafNode
+func (t *Tree[T]) LongestPrefix(s string) (string, T, bool) {
+	var last *leafNode[T]
 	n := t.root
 	search := s
 	for {
@@ -413,11 +419,12 @@ func (t *Tree) LongestPrefix(s string) (string, any, bool) {
 	if last != nil {
 		return last.key, last.val, true
 	}
-	return "", nil, false
+	var zero T
+	return "", zero, false
 }
 
 // Minimum is used to return the minimum value in the tree
-func (t *Tree) Minimum() (string, any, bool) {
+func (t *Tree[T]) Minimum() (string, T, bool) {
 	n := t.root
 	for {
 		if n.isLeaf() {
@@ -429,11 +436,12 @@ func (t *Tree) Minimum() (string, any, bool) {
 			break
 		}
 	}
-	return "", nil, false
+	var zero T
+	return "", zero, false
 }
 
 // Maximum is used to return the maximum value in the tree
-func (t *Tree) Maximum() (string, any, bool) {
+func (t *Tree[T]) Maximum() (string, T, bool) {
 	n := t.root
 	for {
 		if num := len(n.edges); num > 0 {
@@ -445,16 +453,17 @@ func (t *Tree) Maximum() (string, any, bool) {
 		}
 		break
 	}
-	return "", nil, false
+	var zero T
+	return "", zero, false
 }
 
 // Walk is used to walk the tree
-func (t *Tree) Walk(fn WalkFn) {
+func (t *Tree[T]) Walk(fn WalkFn[T]) {
 	recursiveWalk(t.root, fn)
 }
 
 // WalkPrefix is used to walk the tree under a prefix
-func (t *Tree) WalkPrefix(prefix string, fn WalkFn) {
+func (t *Tree[T]) WalkPrefix(prefix string, fn WalkFn[T]) {
 	n := t.root
 	search := prefix
 	for {
@@ -487,7 +496,7 @@ func (t *Tree) WalkPrefix(prefix string, fn WalkFn) {
 // from the root down to a given leaf. Where WalkPrefix walks
 // all the entries *under* the given prefix, this walks the
 // entries *above* the given prefix.
-func (t *Tree) WalkPath(path string, fn WalkFn) {
+func (t *Tree[T]) WalkPath(path string, fn WalkFn[T]) {
 	n := t.root
 	search := path
 	for {
@@ -518,7 +527,7 @@ func (t *Tree) WalkPath(path string, fn WalkFn) {
 
 // recursiveWalk is used to do a pre-order walk of a node
 // recursively. Returns true if the walk should be aborted
-func recursiveWalk(n *node, fn WalkFn) bool {
+func recursiveWalk[T any](n *node[T], fn WalkFn[T]) bool {
 	// Visit the leaf values if any
 	if n.leaf != nil && fn(n.leaf.key, n.leaf.val) {
 		return true
@@ -551,9 +560,9 @@ func recursiveWalk(n *node, fn WalkFn) bool {
 }
 
 // ToMap is used to walk the tree and convert it into a map
-func (t *Tree) ToMap() map[string]any {
-	out := make(map[string]any, t.size)
-	t.Walk(func(k string, v any) bool {
+func (t *Tree[T]) ToMap() map[string]T {
+	out := make(map[string]T, t.size)
+	t.Walk(func(k string, v T) bool {
 		out[k] = v
 		return false
 	})

--- a/radix_test.go
+++ b/radix_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestRadix(t *testing.T) {
 	var min, max string
-	inp := make(map[string]any)
+	inp := make(map[string]int)
 	for i := range 1000 {
 		gen := generateUUID()
 		inp[gen] = i
@@ -28,7 +28,7 @@ func TestRadix(t *testing.T) {
 		t.Fatalf("bad length: %v %v", r.Len(), len(inp))
 	}
 
-	r.Walk(func(k string, v any) bool {
+	r.Walk(func(k string, v int) bool {
 		return false
 	})
 
@@ -67,7 +67,7 @@ func TestRadix(t *testing.T) {
 }
 
 func TestRoot(t *testing.T) {
-	r := New()
+	r := New[bool]()
 	_, ok := r.Delete("")
 	if ok {
 		t.Fatalf("bad")
@@ -87,7 +87,7 @@ func TestRoot(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	r := New()
+	r := New[bool]()
 
 	s := []string{"", "A", "AB"}
 
@@ -120,7 +120,7 @@ func TestDeletePrefix(t *testing.T) {
 	}
 
 	for _, test := range cases {
-		r := New()
+		r := New[bool]()
 		for _, ss := range test.inp {
 			r.Insert(ss, true)
 		}
@@ -131,7 +131,7 @@ func TestDeletePrefix(t *testing.T) {
 		}
 
 		out := []string{}
-		fn := func(s string, v any) bool {
+		fn := func(s string, v bool) bool {
 			out = append(out, s)
 			return false
 		}
@@ -144,7 +144,7 @@ func TestDeletePrefix(t *testing.T) {
 }
 
 func TestLongestPrefix(t *testing.T) {
-	r := New()
+	r := New[any]()
 
 	keys := []string{
 		"",
@@ -182,7 +182,7 @@ func TestLongestPrefix(t *testing.T) {
 	}
 	for _, test := range cases {
 		m, _, ok := r.LongestPrefix(test.inp)
-		if !ok {
+		if !ok && test.out != "" {
 			t.Fatalf("no match: %v", test)
 		}
 		if m != test.out {
@@ -192,7 +192,7 @@ func TestLongestPrefix(t *testing.T) {
 }
 
 func TestWalkPrefix(t *testing.T) {
-	r := New()
+	r := New[any]()
 
 	keys := []string{
 		"foobar",
@@ -271,7 +271,7 @@ func TestWalkPrefix(t *testing.T) {
 }
 
 func TestWalkPath(t *testing.T) {
-	r := New()
+	r := New[any]()
 
 	keys := []string{
 		"foo",
@@ -343,7 +343,7 @@ func TestWalkPath(t *testing.T) {
 }
 
 func TestWalkDelete(t *testing.T) {
-	r := New()
+	r := New[any]()
 	r.Insert("init0/0", nil)
 	r.Insert("init0/1", nil)
 	r.Insert("init0/2", nil)
@@ -392,10 +392,12 @@ func generateUUID() string {
 }
 
 func BenchmarkInsert(b *testing.B) {
-	r := New()
+	r := New[bool]()
 	for i := range 10000 {
 		r.Insert(fmt.Sprintf("init%d", i), true)
 	}
+
+	b.ResetTimer()
 
 	for n := 0; b.Loop(); n++ {
 		_, updated := r.Insert(strconv.Itoa(n), true)
@@ -406,11 +408,11 @@ func BenchmarkInsert(b *testing.B) {
 }
 
 func BenchmarkRadix(b *testing.B) {
-	r := New()
-
 	type v struct {
 		s string
 	}
+	r := New[*v]()
+
 	for i := range 100 {
 		for j := range 100 {
 			r.Insert(fmt.Sprintf("init%d/%d", i, j), &v{s: "hello"})
@@ -421,7 +423,7 @@ func BenchmarkRadix(b *testing.B) {
 
 	b.Run("Walk", func(b *testing.B) {
 		for b.Loop() {
-			r.Walk(func(s string, v any) bool {
+			r.Walk(func(s string, v *v) bool {
 				return false
 			})
 		}
@@ -429,7 +431,7 @@ func BenchmarkRadix(b *testing.B) {
 
 	b.Run("WalkPrefix", func(b *testing.B) {
 		for b.Loop() {
-			r.WalkPrefix("init50", func(s string, v any) bool {
+			r.WalkPrefix("init50", func(s string, v *v) bool {
 				return false
 			})
 		}
@@ -437,15 +439,7 @@ func BenchmarkRadix(b *testing.B) {
 
 	b.Run("WalkPath", func(b *testing.B) {
 		for b.Loop() {
-			r.WalkPath("init50/50", func(s string, v any) bool {
-				return false
-			})
-		}
-	})
-
-	b.Run("Walk", func(b *testing.B) {
-		for b.Loop() {
-			r.Walk(func(s string, v any) bool {
+			r.WalkPath("init50/50", func(s string, v *v) bool {
 				return false
 			})
 		}


### PR DESCRIPTION
Slightly slower walking (the diff is in the calling of the callback function), but insertion is slightly faster and memory efficient, so overall a worth it.

```
                       │ master.bench │         feat-generics.bench         │
                       │    sec/op    │   sec/op     vs base                │
Insert-10                 150.8n ± 2%   147.9n ± 5%  -1.89% (p=0.041 n=6)
Radix/Walk-10             30.93µ ± 0%   33.55µ ± 0%  +8.46% (p=0.002 n=6)
Radix/WalkPrefix-10       273.4n ± 0%   300.3n ± 0%  +9.86% (p=0.002 n=6)
Radix/WalkPath-10         35.39n ± 0%   35.79n ± 0%  +1.13% (p=0.002 n=6)
Radix/Walk#01-10          30.90µ ± 0%
Radix/Get-10              32.32n ± 0%   32.01n ± 0%  -0.96% (p=0.002 n=6)
Radix/LongestPrefix-10    35.43n ± 0%   35.12n ± 0%  -0.87% (p=0.002 n=6)
geomean                   398.5n        197.9n       +2.51%               ¹
¹ benchmark set differs from baseline; geomeans may not be comparable

                       │ master.bench │         feat-generics.bench          │
                       │     B/op     │    B/op     vs base                  │
Insert-10                137.0 ± 0%     129.0 ± 0%  -5.84% (p=0.002 n=6)
Radix/Walk-10            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Radix/WalkPrefix-10      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Radix/WalkPath-10        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Radix/Walk#01-10         0.000 ± 0%
Radix/Get-10             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Radix/LongestPrefix-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                             ²               -1.00%               ³ ²
¹ all samples are equal
² summaries must be >0 to compute geomean
³ benchmark set differs from baseline; geomeans may not be comparable

                       │ master.bench │         feat-generics.bench          │
                       │  allocs/op   │ allocs/op   vs base                  │
Insert-10                3.000 ± 0%     3.000 ± 0%       ~ (p=1.000 n=6) ¹
Radix/Walk-10            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Radix/WalkPrefix-10      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Radix/WalkPath-10        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Radix/Walk#01-10         0.000 ± 0%
Radix/Get-10             0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
Radix/LongestPrefix-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=6) ¹
geomean                             ²               +0.00%               ³ ²
````
