### PR TITLE
Fix potential data race in Walk

### DIFF
--- a/radix.go
+++ b/radix.go
@@ -10,8 +10,9 @@ type WalkFlag uint32
 
 const (
 	WalkContinue WalkFlag = 0
-	WalkStop     WalkFlag = 1 << 0
-	WalkSet      WalkFlag = 1 << 1
+	WalkSkip     WalkFlag = 1 << 0
+	WalkStop     WalkFlag = 1 << 1
+	WalkSet      WalkFlag = 1 << 2
 )
 
 // ShouldStop returns true if the walk should terminate.
@@ -24,10 +25,31 @@ func (w WalkFlag) ShouldSet() bool {
 	return w&WalkSet != 0
 }
 
+// ShouldSkip returns true if the walk should skip this node.
+func (w WalkFlag) ShouldSkip() bool {
+	return w&WalkSkip != 0
+}
+
 // WalkFn is used when walking the tree. Takes a
 // key and value, returning a WalkFlag to indicate
 // how to proceed and possibly a new value to set.
 type WalkFn[T any] func(s string, v T) (WalkFlag, T)
+
+func (wf WalkFn[T]) Check(s string) WalkFlag {
+	return WalkContinue
+}
+
+func (wf WalkFn[T]) Handle(s string, v T) (WalkFlag, T) {
+	return wf(s, v)
+}
+
+// WalkHandler is the handler passed to Walk functions.
+// When split into two steps, this allows us to walk the
+// keys withut reading the values.
+type WalkHandler[T any] interface {
+	Check(s string) WalkFlag
+	Handle(s string, v T) (WalkFlag, T)
+}
 
 // leafNode is used to represent a value
 type leafNode[T any] struct {
@@ -332,11 +354,12 @@ func (t *Tree[T]) deletePrefix(parent, n *node[T], prefix string) int {
 	if len(prefix) == 0 {
 		// Remove the leaf node
 		subTreeSize := 0
-		// recursively walk from all edges of the node to be deleted
-		recursiveWalk(n, func(s string, v T) (WalkFlag, T) {
+		var fn WalkFn[T] = func(s string, v T) (WalkFlag, T) {
 			subTreeSize++
 			return WalkContinue, v
-		})
+		}
+		// recursively walk from all edges of the node to be deleted
+		recursiveWalk(n, fn)
 		if n.isLeaf() {
 			n.leaf = nil
 		}
@@ -477,18 +500,18 @@ func (t *Tree[T]) Maximum() (string, T, bool) {
 }
 
 // Walk is used to walk the tree
-func (t *Tree[T]) Walk(fn WalkFn[T]) {
-	recursiveWalk(t.root, fn)
+func (t *Tree[T]) Walk(h WalkHandler[T]) {
+	recursiveWalk(t.root, h)
 }
 
 // WalkPrefix is used to walk the tree under a prefix
-func (t *Tree[T]) WalkPrefix(prefix string, fn WalkFn[T]) {
+func (t *Tree[T]) WalkPrefix(prefix string, h WalkHandler[T]) {
 	n := t.root
 	search := prefix
 	for {
 		// Check for key exhaustion
 		if len(search) == 0 {
-			recursiveWalk(n, fn)
+			recursiveWalk(n, h)
 			return
 		}
 
@@ -505,7 +528,7 @@ func (t *Tree[T]) WalkPrefix(prefix string, fn WalkFn[T]) {
 		}
 		if strings.HasPrefix(n.prefix, search) {
 			// Child may be under our search prefix
-			recursiveWalk(n, fn)
+			recursiveWalk(n, h)
 		}
 		return
 	}
@@ -515,22 +538,28 @@ func (t *Tree[T]) WalkPrefix(prefix string, fn WalkFn[T]) {
 // from the root down to a given leaf. Where WalkPrefix walks
 // all the entries *under* the given prefix, this walks the
 // entries *above* the given prefix.
-func (t *Tree[T]) WalkPath(path string, fn WalkFn[T]) {
+func (t *Tree[T]) WalkPath(path string, h WalkHandler[T]) {
 	n := t.root
 	search := path
 	for {
 		// Visit the leaf values if any
 		if n.leaf != nil {
-			f, n2 := fn(n.leaf.key, n.leaf.val)
-			if f.ShouldSet() {
-				n.leaf.val = n2
-			}
+			f := h.Check(n.leaf.key)
 			if f.ShouldStop() {
 				return
 			}
+			if !f.ShouldSkip() {
+				f, n2 := h.Handle(n.leaf.key, n.leaf.val)
+				if f.ShouldSet() {
+					n.leaf.val = n2
+				}
+				if f.ShouldStop() {
+					return
+				}
+			}
 		}
 
-		// Check for key exhaution
+		// Check for key exhaustion
 		if len(search) == 0 {
 			return
 		}
@@ -552,15 +581,21 @@ func (t *Tree[T]) WalkPath(path string, fn WalkFn[T]) {
 
 // recursiveWalk is used to do a pre-order walk of a node
 // recursively. Returns true if the walk should be aborted
-func recursiveWalk[T any](n *node[T], fn WalkFn[T]) bool {
+func recursiveWalk[T any](n *node[T], h WalkHandler[T]) bool {
 	// Visit the leaf values if any
 	if n.leaf != nil {
-		f, n2 := fn(n.leaf.key, n.leaf.val)
-		if f.ShouldSet() {
-			n.leaf.val = n2
-		}
+		f := h.Check(n.leaf.key)
 		if f.ShouldStop() {
 			return true
+		}
+		if !f.ShouldSkip() {
+			f, n2 := h.Handle(n.leaf.key, n.leaf.val)
+			if f.ShouldSet() {
+				n.leaf.val = n2
+			}
+			if f.ShouldStop() {
+				return true
+			}
 		}
 	}
 
@@ -569,7 +604,7 @@ func recursiveWalk[T any](n *node[T], fn WalkFn[T]) bool {
 	k := len(n.edges) // keeps track of number of edges in previous iteration
 	for i < k {
 		e := n.edges[i]
-		if recursiveWalk(e.node, fn) {
+		if recursiveWalk(e.node, h) {
 			return true
 		}
 		// It is a possibility that the WalkFn modified the node we are
@@ -577,7 +612,7 @@ func recursiveWalk[T any](n *node[T], fn WalkFn[T]) bool {
 		// so the last edge became the current node n, on which we'll
 		// iterate one last time.
 		if len(n.edges) == 0 {
-			return recursiveWalk(n, fn)
+			return recursiveWalk(n, h)
 		}
 		// If there are now less edges than in the previous iteration,
 		// then do not increment the loop index, since the current index
@@ -594,9 +629,10 @@ func recursiveWalk[T any](n *node[T], fn WalkFn[T]) bool {
 func (t *Tree[T]) ToMap() map[string]T {
 	out := make(map[string]T, t.size)
 	var zero T
-	t.Walk(func(k string, v T) (WalkFlag, T) {
+	var fn WalkFn[T] = func(k string, v T) (WalkFlag, T) {
 		out[k] = v
 		return WalkContinue, zero
-	})
+	}
+	t.Walk(fn)
 	return out
 }

--- a/radix_test.go
+++ b/radix_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"sync"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -28,9 +29,10 @@ func TestRadix(t *testing.T) {
 	r := NewFromMap(inp)
 	c.Assert(r.Len(), qt.Equals, len(inp))
 
-	r.Walk(func(k string, v int) (WalkFlag, int) {
+	var fn WalkFn[int] = func(s string, v int) (WalkFlag, int) {
 		return WalkContinue, v
-	})
+	}
+	r.Walk(fn)
 
 	for k, v := range inp {
 		out, ok := r.Get(k)
@@ -69,30 +71,135 @@ func TestRoot(t *testing.T) {
 
 func TestWalkSet(t *testing.T) {
 	c := qt.New(t)
+
+	newTree := func() *Tree[int] {
+		r := New[int]()
+
+		for i := range 10 {
+			r.Insert(fmt.Sprintf("key%d", i), i)
+		}
+		return r
+	}
+
+	collect := func(r *Tree[int]) []int {
+		var ints []int
+		var fn WalkFn[int] = func(s string, v int) (WalkFlag, int) {
+			ints = append(ints, v)
+			return WalkContinue, 0
+		}
+		r.Walk(fn)
+		return ints
+	}
+
+	c.Run("Basic", func(c *qt.C) {
+		var fn WalkFn[int] = func(s string, v int) (WalkFlag, int) {
+			k := fmt.Sprintf("key%d", v)
+			c.Assert(s, qt.Equals, k)
+			v2 := v
+			if v%2 == 0 {
+				v2 = v * 10
+				return WalkSet, v2
+			}
+			return WalkContinue, 0
+		}
+
+		r := newTree()
+		r.Walk(fn)
+
+		c.Assert(collect(r), qt.DeepEquals, []int{0, 1, 20, 3, 40, 5, 60, 7, 80, 9})
+	})
+
+	c.Run("Skip some ", func(c *qt.C) {
+		r := newTree()
+		h := testWalkHandler[int]{
+			check: func(s string) WalkFlag {
+				if s == "key4" || s == "key7" {
+					return WalkSkip
+				}
+				return WalkContinue
+			},
+			handle: func(s string, v int) (WalkFlag, int) {
+				return WalkSet, v * 10
+			},
+		}
+		r.Walk(h)
+
+		c.Assert(collect(r), qt.DeepEquals, []int{0, 10, 20, 30, 4, 50, 60, 7, 80, 90})
+	})
+
+	c.Run("Stop in check", func(c *qt.C) {
+		r := newTree()
+		h := testWalkHandler[int]{
+			check: func(s string) WalkFlag {
+				if s == "key4" {
+					return WalkStop
+				}
+				return WalkContinue
+			},
+			handle: func(s string, v int) (WalkFlag, int) {
+				return WalkSet, v * 10
+			},
+		}
+		r.Walk(h)
+
+		c.Assert(collect(r), qt.DeepEquals, []int{0, 10, 20, 30, 4, 5, 6, 7, 8, 9})
+	})
+
+	c.Run("Stop in handle", func(c *qt.C) {
+		r := newTree()
+		h := testWalkHandler[int]{
+			check: func(s string) WalkFlag {
+				return WalkContinue
+			},
+			handle: func(s string, v int) (WalkFlag, int) {
+				if s == "key4" {
+					return WalkStop, 0
+				}
+				return WalkSet, v * 10
+			},
+		}
+		r.Walk(h)
+
+		c.Assert(collect(r), qt.DeepEquals, []int{0, 10, 20, 30, 4, 5, 6, 7, 8, 9})
+	})
+}
+
+func TestWalkSetParallel(t *testing.T) {
+	c := qt.New(t)
+
 	r := New[int]()
 
-	for i := range 10 {
+	for i := range 1000 {
 		r.Insert(fmt.Sprintf("key%d", i), i)
 	}
 
-	r.Walk(func(s string, v int) (WalkFlag, int) {
-		k := fmt.Sprintf("key%d", v)
-		c.Assert(s, qt.Equals, k)
-		v2 := v
-		if v%2 == 0 {
-			v2 = v * 10
-			return WalkSet, v2
-		}
-		return WalkContinue, 0
-	})
+	var wg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(j int) {
+			defer wg.Done()
+			if j == 2 {
+				var fn WalkFn[int] = func(s string, v int) (WalkFlag, int) {
+					return WalkSet, v * 3
+				}
+				r.Walk(fn)
+			} else {
+				r.Walk(testWalkHandler[int]{})
+			}
+		}(i)
+	}
+
+	wg.Wait()
 
 	var ints []int
-	r.Walk(func(s string, v int) (WalkFlag, int) {
+	var fn WalkFn[int] = func(s string, v int) (WalkFlag, int) {
 		ints = append(ints, v)
 		return WalkContinue, 0
-	})
+	}
+	r.Walk(fn)
 
-	c.Assert(ints, qt.DeepEquals, []int{0, 1, 20, 3, 40, 5, 60, 7, 80, 9})
+	c.Assert(ints[:5], qt.DeepEquals, []int{0, 3, 30, 300, 303})
 }
 
 func TestWalkFlag(t *testing.T) {
@@ -101,10 +208,14 @@ func TestWalkFlag(t *testing.T) {
 	f := WalkSet
 	c.Assert(f.ShouldSet(), qt.IsTrue)
 	c.Assert(f.ShouldStop(), qt.IsFalse)
+	c.Assert(f.ShouldSkip(), qt.IsFalse)
 
 	f = WalkSet | WalkStop
 	c.Assert(f.ShouldSet(), qt.IsTrue)
 	c.Assert(f.ShouldStop(), qt.IsTrue)
+
+	f = WalkSkip
+	c.Assert(f.ShouldSkip(), qt.IsTrue)
 }
 
 func TestDelete(t *testing.T) {
@@ -150,7 +261,7 @@ func TestDeletePrefix(t *testing.T) {
 		c.Assert(deleted, qt.Equals, test.numDeleted)
 
 		out := []string{}
-		fn := func(s string, v bool) (WalkFlag, bool) {
+		var fn WalkFn[bool] = func(s string, v bool) (WalkFlag, bool) {
 			out = append(out, s)
 			return WalkContinue, false
 		}
@@ -270,7 +381,7 @@ func TestWalkPrefix(t *testing.T) {
 
 	for _, test := range cases {
 		out := []string{}
-		fn := func(s string, v string) (WalkFlag, string) {
+		var fn WalkFn[string] = func(s string, v string) (WalkFlag, string) {
 			out = append(out, s)
 			return WalkContinue, ""
 		}
@@ -339,7 +450,7 @@ func TestWalkPath(t *testing.T) {
 
 	for _, test := range cases {
 		out := []string{}
-		fn := func(s string, v string) (WalkFlag, string) {
+		var fn WalkFn[string] = func(s string, v string) (WalkFlag, string) {
 			out = append(out, s)
 			return WalkContinue, ""
 		}
@@ -363,7 +474,7 @@ func TestWalkDelete(t *testing.T) {
 	r.Insert("init1/3", "")
 	r.Insert("init2", "")
 
-	deleteFn := func(s string, v string) (WalkFlag, string) {
+	var deleteFn WalkFn[string] = func(s string, v string) (WalkFlag, string) {
 		r.Delete(s)
 		return WalkContinue, ""
 	}
@@ -423,29 +534,41 @@ func BenchmarkRadix(b *testing.B) {
 		}
 	}
 
+	var fn WalkFn[*v] = func(s string, v *v) (WalkFlag, *v) {
+		return WalkContinue, nil
+	}
+
+	skipAll := testWalkHandler[*v]{}
+
 	b.ResetTimer()
 
 	b.Run("Walk", func(b *testing.B) {
 		for b.Loop() {
-			r.Walk(func(s string, v *v) (WalkFlag, *v) {
-				return WalkContinue, nil
-			})
+			r.Walk(fn)
+		}
+	})
+
+	b.Run("Walk keys", func(b *testing.B) {
+		for b.Loop() {
+			r.Walk(skipAll)
 		}
 	})
 
 	b.Run("WalkPrefix", func(b *testing.B) {
 		for b.Loop() {
-			r.WalkPrefix("init50", func(s string, v *v) (WalkFlag, *v) {
-				return WalkContinue, nil
-			})
+			r.WalkPrefix("init50", fn)
+		}
+	})
+
+	b.Run("WalkPrefix keys", func(b *testing.B) {
+		for b.Loop() {
+			r.WalkPrefix("init50", skipAll)
 		}
 	})
 
 	b.Run("WalkPath", func(b *testing.B) {
 		for b.Loop() {
-			r.WalkPath("init50/50", func(s string, v *v) (WalkFlag, *v) {
-				return WalkContinue, nil
-			})
+			r.WalkPath("init50/50", fn)
 		}
 	})
 
@@ -465,4 +588,24 @@ func BenchmarkRadix(b *testing.B) {
 			c.Assert(ok, qt.IsTrue)
 		}
 	})
+}
+
+type testWalkHandler[T any] struct {
+	check  func(s string) WalkFlag
+	handle func(s string, v T) (WalkFlag, T)
+}
+
+func (w testWalkHandler[T]) Check(s string) WalkFlag {
+	if w.check != nil {
+		return w.check(s)
+	}
+	return WalkSkip
+}
+
+func (w testWalkHandler[T]) Handle(s string, v T) (WalkFlag, T) {
+	if w.handle != nil {
+		return w.handle(s, v)
+	}
+	var zero T
+	return WalkContinue, zero
 }


### PR DESCRIPTION
The construct in #3 was added to allow setting values while walking but also allow other goroutines to walk the tree concurrently.

But that premiss was flawed, as any walk would read the leaf values, hence causing a potential data race.

This changes makes the Walk take an interface with an option al pre Check method that takes only the key, and a Handle method that takes both key and value.
This allows the caller to skip reading the value if not needed.
